### PR TITLE
Felddefinition als Value eines Addons kennzeichnen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -1,1 +1,3 @@
-bs5_iconpicker_title: Bootstrap 5 Icons
+bs5_iconpicker_title = Bootstrap 5 Icons
+
+yform_values_bs5_iconpicker_description = 🧩 Bootstrap Icons: Stellt einen Icon-Picker zur Verfügung.

--- a/lib/yform/value/bs5_iconpicker.php
+++ b/lib/yform/value/bs5_iconpicker.php
@@ -46,7 +46,7 @@ class rex_yform_value_bs5_iconpicker extends rex_yform_value_text
                 'attributes' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
                 'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
             ],
-            'description' => rex_i18n::msg('yform_values_text_description'),
+            'description' => rex_i18n::msg('yform_values_bs5_iconpicker_description'),
             'db_type' => ['varchar(191)', 'text'],
             'famous' => false,
             'hooks' => [

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: bs5_iconpicker 
-version: '1.0.6' 
+version: '1.0.7' 
 author: 'Alexander Walther, Thorben' 
 supportpage: https://github.com/alexplusde/bs5_iconpicker 
 


### PR DESCRIPTION
Ergänzt die Felddefinition, um zu zeigen, dass das Feld von bs5_iconpicker kommt.